### PR TITLE
Fix issues caused by rust-cache.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -53,6 +53,9 @@ fn main() {
                 .expect("handler doesn't have a file name"),
         );
 
+        // Make sure we re-copy the file to the desired output directory if it
+        // gets deleted.
+        println!("cargo:rerun-if-changed={}", bin_path.display());
         fs::copy(&handler, &bin_path).expect("failed to copy sentry crash handler");
     }
 }


### PR DESCRIPTION
## Description

This PR ensures that, if the Swatinem/rust-cache action deletes the `crashpad_handler` file from the target directory, this build script will be re-run and will re-copy the file into its expected location.

## Testing

Tested this locally by building a WarpLocal bundle with `./script/bundle`, deleting `target/$PROFILE/crashpad_handler`, and then re-running the bundle script.  Before this PR, the bundling fails due to not finding the binary; after this PR, the build script is re-run and everything works as expected.