### PR TITLE
Remove the `sentry_remove_transaction` function from `sentry-contrib-native-sys`

### DIFF
--- a/sentry-contrib-native-sys/src/lib.rs
+++ b/sentry-contrib-native-sys/src/lib.rs
@@ -813,10 +813,6 @@ extern "C" {
     #[link_name = "sentry_set_transaction"]
     pub fn set_transaction(transaction: *const c_char);
 
-    /// Removes the transaction.
-    #[link_name = "sentry_remove_transaction"]
-    pub fn remove_transaction();
-
     /// Sets the event level.
     #[link_name = "sentry_set_level"]
     pub fn set_level(level: i32);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -516,7 +516,7 @@ pub fn set_transaction<S: Into<String>>(transaction: S) {
 /// remove_transaction();
 /// ```
 pub fn remove_transaction() {
-    unsafe { sys::remove_transaction() }
+    unsafe { sys::set_transaction(ptr::null()) }
 }
 
 /// Sets the event level.


### PR DESCRIPTION
The version of Sentry Native that this fork depends on does not include the `sentry_remove_transaction`  function (it was removed in https://github.com/getsentry/sentry-native/pull/652/).

This PR:
1) Removes the function from the sys crate
2) Reimplements `remove_transaction` in `sentry-contrib-native` (the non sys version of the crate) by passing a null ptr to that function, as suggested in this comment: https://github.com/getsentry/sentry-native/pull/652/files#r783840893

I'm unable to compile this crate on Windows because of this issue.